### PR TITLE
Paranna tehtävän 59 testejä

### DIFF
--- a/tasks/task59.txt
+++ b/tasks/task59.txt
@@ -23,3 +23,20 @@ INSERT INTO Sanat (sana) VALUES ('oppilas');
 RESULT
 apina
 oppia
+
+TEST
+INSERT INTO Sanat (sana) VALUES ('paino');
+INSERT INTO Sanat (sana) VALUES ('upeus');
+INSERT INTO Sanat (sana) VALUES ('pappi');
+
+RESULT
+upeus
+
+TEST
+INSERT INTO Sanat (sana) VALUES ('opus');
+INSERT INTO Sanat (sana) VALUES ('upota');
+INSERT INTO Sanat (sana) VALUES ('sapluuna');
+INSERT INTO Sanat (sana) VALUES ('opisto');
+
+RESULT
+upota


### PR DESCRIPTION
SQLtrainer-tehtävä 59 hyväksyy myös ratkaisut, joissa kysely noutaa vaadittujen lisäksi myös sellaiset 5-pituiset sanat, joissa positiossa 2 ei ole kirjainta p, kunhan se on jossain muualla. 
Tämä korjannee kyseisen puutteen.